### PR TITLE
Fixed device or resource busy error for the 2018 Buttonbox in Linux

### DIFF
--- a/rusocsci/utils.py
+++ b/rusocsci/utils.py
@@ -207,11 +207,20 @@ def open(port):
 	except:
 		pass
 
-	try:
-		device = serial.Serial(port, baudrate=115200, parity='N', timeout = 0.0)  # open serial port
-	except Exception as e:
-		logging.error("Could not connect to serial port {}: \n{}".format(port, e))
-		return None
+
+	device = None
+	while device is None:
+		try:
+			device = serial.Serial(port, baudrate=115200, parity='N', timeout = 0.0)  # open serial port
+   #     	except Exception as e:
+        	except serial.serialutil.SerialException as e:
+			if 'Device or resource busy:' in e.__str__():
+				logging.debug('Opening COM port is taking a little while, please stand by...')
+        		else:
+				logging.error("Could not connect to serial port {}: \n{}".format(port, e))
+				return None
+        		time.sleep(1)
+
 		
 	# reset connection
 	device.flushInput()


### PR DESCRIPTION
The new 2018 buttonbox gives a device or resource busy error. I found a fix here:

Motsai/neblina-python@544b14a

and implemented it in RuSocSci.